### PR TITLE
refactor: 認証方式をセッションからJWTへ移行

### DIFF
--- a/auth_service.ts
+++ b/auth_service.ts
@@ -1,13 +1,24 @@
-// auth_service.ts (Before)
+// auth_service.ts (After)
+import jwt from 'jsonwebtoken';
+
+// 環境変数からシークレットキーを取得（新規追加）
+const JWT_SECRET = process.env.JWT_SECRET;
+
 export const login = (user: User) => {
-  // セッションにユーザー情報を保存
-  session.save({
-    userId: user.id,
-    isLoggedIn: true
-  });
-  return "Session created";
+  // セッション方式からJWT方式へ変更
+  const token = jwt.sign(
+    { userId: user.id }, 
+    JWT_SECRET, 
+    { expiresIn: '1h' }
+  );
+  
+  return {
+    accessToken: token,
+    tokenType: "Bearer"
+  };
 };
 
 export const logout = () => {
-  session.destroy();
+  // クライアント側でトークンを破棄するため、サーバー処理を廃止
+  return "Please delete token on client side";
 };


### PR DESCRIPTION
**変更の背景**
スケーラビリティ向上のため、ステートフルなセッション管理を廃止し、ステートレスなJWT認証に移行しました。

**主な変更点**
- jsonwebtoken ライブラリの導入。
- ログイン成功時に accessToken を返す形式に変更。
- 認証用シークレットキーとして環境変数 JWT_SECRET を定義。

**ドキュメント更新のポイント**
戻り値の型が文字列からオブジェクトに変更されているため、APIリファレンスの更新をお願いします。